### PR TITLE
Add _docs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-docs/
+_docs/
 
 *.bak
 .gitattributes


### PR DESCRIPTION
It seems like after this commit https://github.com/fastai/nbprocess-template/commit/fc4843620e24aa9f16db31263edf652c75266f83
`_docs` should be in .gitignore instead of `docs`

When I created a new nbprocess project the `_docs` folder was untracked and I had to add it to .gitignore manually

@hamelsmu 