### PR TITLE
fix github repo url in settings template

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -9,6 +9,7 @@ keywords = {keywords}
 user = {user}
 author = {author}
 author_email = {author_email}
+repo = {repo}
 branch = {branch}
 version = 0.0.1
 min_python = 3.9
@@ -25,7 +26,7 @@ tst_flags = notest
 ### Inferred From Other Values ###
 doc_host =  https://%(user)s.github.io
 doc_baseurl = /%(lib_name)s/
-git_url = https://github.com/%(user)s/%(lib_name)s/tree/%(branch)s/
+git_url = https://github.com/%(user)s/%(repo)s/
 lib_path = %(lib_name)s
 title = %(lib_name)s
 


### PR DESCRIPTION
Makes `git_url` to be the base URL to the git repo.


Related to issue https://github.com/fastai/nbprocess/issues/115