### PR TITLE
Support git requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from pkg_resources import parse_version
 from configparser import ConfigParser
-import setuptools
+import setuptools, shlex
 assert parse_version(setuptools.__version__)>=parse_version('36.2')
 
 # note: all settings are in settings.ini; edit there, not here
@@ -24,8 +24,8 @@ statuses = [ '1 - Planning', '2 - Pre-Alpha', '3 - Alpha',
     '4 - Beta', '5 - Production/Stable', '6 - Mature', '7 - Inactive' ]
 py_versions = '3.6 3.7 3.8 3.9 3.10'.split()
 
-requirements = cfg.get('requirements','').split()
-if cfg.get('pip_requirements'): requirements += cfg.get('pip_requirements','').split()
+requirements = shlex.split(cfg.get('requirements', ''))
+if cfg.get('pip_requirements'): requirements += shlex.split(cfg.get('pip_requirements', ''))
 min_python = cfg['min_python']
 lic = licenses.get(cfg['license'].lower(), (cfg['license'], None))
 dev_requirements = (cfg.get('dev_requirements') or '').split()


### PR DESCRIPTION
Using the previous split method to parse requirements (`cfg.get('requirements','').split()`) I was unable to add requirements such as:
`"some_repo @ git+https://github.com/some-user/some-repo@main"`

This works correctly with `shlex.split`.