### PR TITLE
add 'conda/' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 .Python
 env/
 build/
+conda/
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
i think the 'conda' folder should be in the .gitignore section related to packaging, since those are generated artifacts.