### PR TITLE
more useful index.ipynb file

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -11,6 +11,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,6 +21,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -27,22 +29,175 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Install"
+    "## Developer Guide"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```sh\n",
-    "pip install {{lib_path}}\n",
+    "If you are new to using `nbdev` here are some useful pointers to get you started."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It can be helpful to have a dedicated environment for development. Here we are assuming that you have an conda environment file called `env.yml` named after `{{lib_path}}` i.e.:\n",
+    "\n",
+    "```yaml\n",
+    "# env.yml\n",
+    "name: {{lib_path}}\n",
+    "\n",
+    "channels:\n",
+    "  - fastai\n",
+    "\n",
+    "dependencies:\n",
+    "  - fastai::nbdev>=2.3.12\n",
+    "# - python>=3.11  # specify python version if required \n",
+    "# - dependency 1\n",
+    "# - dependency 2\n",
+    "# - pip\n",
+    "# pip:\n",
+    "#   - pip dependency 1\n",
+    "#   - pip dependency 2\n",
     "```"
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can then use `conda` or `mamba` (faster at resolving) to create and update your environment file should your needs change as you work on `{{lib_path}}`"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```sh\n",
+    "# create a conda environment for working on {{repo}}\n",
+    "$ mamba env create -f env.yml\n",
+    "\n",
+    "# update conda environment\n",
+    "$ mamba env update -n {{lib_path}} --file env.yml\n",
+    "```"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install {{lib_path}} in Development mode"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```sh\n",
+    "# activate conda environment\n",
+    "$ conda activate {{lib_path}}\n",
+    "\n",
+    "# make sure {{lib_path}} package is installed in development mode\n",
+    "$ pip install -e .\n",
+    "\n",
+    "# make changes under nbs/ directory\n",
+    "# ...\n",
+    "\n",
+    "# compile to have changes apply to {{lib_path}}\n",
+    "$ nbdev_prepare\n",
+    "```"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usage"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Install latest from the GitHub [repository][repo]:\n",
+    "\n",
+    "```sh\n",
+    "$ pip install git+https://github.com/{{user}}/{{lib_name}}.git\n",
+    "```\n",
+    "\n",
+    "or from [conda][conda]\n",
+    "\n",
+    "```sh\n",
+    "$ conda install -c {{user}} {{lib_path}}\n",
+    "```\n",
+    "\n",
+    "or from [pypi][pypi]\n",
+    "\n",
+    "\n",
+    "```sh\n",
+    "$ pip install {{lib_path}}\n",
+    "```\n",
+    "\n",
+    "\n",
+    "[repo]: {{git_url}}\n",
+    "[docs]: https://{{user}}.github.io/{{lib_name}}/\n",
+    "[pypi]: https://pypi.org/project/{{lib_name}}/\n",
+    "[conda]: https://anaconda.org/{{user}}/{{lib_name}}"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Documentation"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Documentation can be found hosted on this GitHub [repository][repo]'s [pages][docs]. Additionally you can find package manager specific guidelines on [conda][conda] and [pypi][pypi] respectively.\n",
+    "\n",
+    "[repo]: {{git_url}}\n",
+    "[docs]: https://{{user}}.github.io/{{lib_name}}/\n",
+    "[pypi]: https://pypi.org/project/{{lib_name}}/\n",
+    "[conda]: https://anaconda.org/{{user}}/{{lib_name}}"
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -50,6 +205,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Since it is a template file anyway it is easy to delete everything, I though it might be useful for onboarding purposes if the default `index.ipynb` had some more directed content.