### PR TITLE
Pedagogical: readme + dev defaults update

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "```sh\n",
     "# make sure {{lib_path}} package is installed in development mode\n",
-    "$ pip install -e .\n",
+    "$ pip install -e .[dev]\n",
     "\n",
     "# make changes under nbs/ directory\n",
     "# ...\n",

--- a/settings.ini
+++ b/settings.ini
@@ -10,7 +10,7 @@ version = 0.0.1
 ### OPTIONAL ###
 
 # requirements = fastcore
-# dev_requirements = 
+# dev_requirements = ipykernel
 # console_scripts =
 
 ### nbdev ###


### PR DESCRIPTION
If based on [limited experience](https://github.com/tkukurin/pygenv) I understand the nbdev workflow, it seems desirable to include `ipykernel` as a dependency as default suggestion for new users.

Related change: instruction to install in development mode seems to be missing the `dev` extra.