### PR TITLE
Critical Bugfix: Run nbdev_clean to make sure nbs/index.ipynb conform to the standard

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -170,21 +170,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Issue this PR solves

[nbdev-ci Github Action](https://github.com/AnswerDotAI/workflows/blob/master/nbdev-ci/action.yml#L71-L74) will do a `nbdev_clean` and check `git status` to make sure all notebooks conform to the nbdev_clean standard. However, the existing `nbs/index.ipynb` does not satisfy this standard. This causes `nbdev-ci` workflow to fail, which in turn makes all users following the [nbdev tutorial](https://nbdev.fast.ai/tutorials/tutorial.html#check-out-your-workflows) fail and get confusing at the step.
I love the literate + exploratory programming principle and would love to push it further. Therefore, such issue blocking new users' onboarding should be fixed with priority.

## Minimal Reproducible Example (b4 and after fix)

### Before Fix
Simply follow the tutorial and the first Github Action run will fail: [At log line 250 nbdev_clean runs and at line 254 git status check fails](https://github.com/deephbz/nbdev-demo/actions/runs/12513880448/job/34909128756#step:2:262).

### After Fix
[This Github Action is run on a PRed branch of the same repo](https://github.com/deephbz/nbdev-demo/actions/runs/12513904424). The PR change is the same as what's proposed in this PR.