### PR TITLE
fix: update workflow paths from fastai to answerdotai

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,4 +11,4 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    steps: [uses: fastai/workflows/quarto-ghp@master]
+    steps: [uses: answerdotai/workflows/quarto-ghp@master]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,4 +4,4 @@ on:  [workflow_dispatch, pull_request, push]
 jobs:
   test:
     runs-on: ubuntu-latest
-    steps: [uses: fastai/workflows/nbdev-ci@master]
+    steps: [uses: answerdotai/workflows/nbdev-ci@master]


### PR DESCRIPTION
Fixes #20

Problem:
The workflow files reference `fastai/workflows` which now redirects to `answerdotai/workflows`. While regular GitHub accounts follow this redirect automatically, Enterprise accounts are more strict about redirects, causing the workflows to fail.

Changes:
- Updated workflow references in `.github/workflows/test.yaml` from `fastai/workflows/nbdev-ci@master` to `answerdotai/workflows/nbdev-ci@master`
- Updated workflow references in `.github/workflows/deploy.yaml` from `fastai/workflows/quarto-ghp@master` to `answerdotai/workflows/quarto-ghp@master`
