### PR TITLE
Modernize license handling to use SPDX expressions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ for o in expected: assert o in cfg, "missing expected setting: {}".format(o)
 setup_cfg = {o:cfg[o] for o in cfg_keys}
 
 licenses = {
-    'apache2': ('Apache Software License 2.0','OSI Approved :: Apache Software License'),
-    'mit': ('MIT License', 'OSI Approved :: MIT License'),
-    'gpl2': ('GNU General Public License v2', 'OSI Approved :: GNU General Public License v2 (GPLv2)'),
-    'gpl3': ('GNU General Public License v3', 'OSI Approved :: GNU General Public License v3 (GPLv3)'),
-    'bsd3': ('BSD License', 'OSI Approved :: BSD License'),
+    'apache2': 'Apache-2.0',
+    'mit': 'MIT',
+    'gpl2': 'GPL-2.0-only',
+    'gpl3': 'GPL-3.0-or-later',
+    'bsd3': 'BSD-3-Clause',
 }
 statuses = [ '1 - Planning', '2 - Pre-Alpha', '3 - Alpha',
     '4 - Beta', '5 - Production/Stable', '6 - Mature', '7 - Inactive' ]
@@ -27,7 +27,6 @@ py_versions = '3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13'.split()
 requirements = shlex.split(cfg.get('requirements', ''))
 if cfg.get('pip_requirements'): requirements += shlex.split(cfg.get('pip_requirements', ''))
 min_python = cfg['min_python']
-lic = licenses.get(cfg['license'].lower(), (cfg['license'], None))
 dev_requirements = (cfg.get('dev_requirements') or '').split()
 
 package_data = dict()
@@ -39,12 +38,12 @@ setup_cfg['package_data'] = package_data
 
 setuptools.setup(
     name = cfg['lib_name'],
-    license = lic[0],
+    license = licenses.get(cfg['license'].lower(), cfg['license']),
     classifiers = [
         'Development Status :: ' + statuses[int(cfg['status'])],
         'Intended Audience :: ' + cfg['audience'].title(),
         'Natural Language :: ' + cfg['language'].title(),
-    ] + ['Programming Language :: Python :: '+o for o in py_versions[py_versions.index(min_python):]] + (['License :: ' + lic[1] ] if lic[1] else []),
+    ] + ['Programming Language :: Python :: '+o for o in py_versions[py_versions.index(min_python):]],
     url = cfg['git_url'],
     packages = setuptools.find_packages(),
     include_package_data = True,


### PR DESCRIPTION
`nbdev_pypi` raises the following warnings:

```
.../.venv/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

**This PR:**
- Replace deprecated license classifiers with modern SPDX expressions
- Remove 'License :: OSI Approved :: *' classifiers that cause setuptools warnings
- Update license mapping to use [SPDX identifiers](https://spdx.org/licenses/) (Apache-2.0, MIT, etc.)
- Simplify license handling logic since we no longer need tuples